### PR TITLE
Add default CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @privacy-scaling-explorations/excubiae


### PR DESCRIPTION
Through Github rulesets and the definition of code owners, it is possible to automate the review process without additional workflows. It also makes responsibilities within the project clearer. The current CODEOWNERS file is very simple just including the `@privacy-scaling-explorations/excubiae` team as owners.
