### PR TITLE
fix(contracts): add view modifier for getAppendedBytes method

### DIFF
--- a/packages/contracts/contracts/interfaces/IClone.sol
+++ b/packages/contracts/contracts/interfaces/IClone.sol
@@ -14,5 +14,5 @@ interface IClone {
 
     /// @notice Retrieves appended bytes from the clone's runtime bytecode.
     /// @return Appended bytes passed during the clone's creation.
-    function getAppendedBytes() external returns (bytes memory);
+    function getAppendedBytes() external view returns (bytes memory);
 }

--- a/packages/contracts/contracts/proxy/Clone.sol
+++ b/packages/contracts/contracts/proxy/Clone.sol
@@ -22,7 +22,7 @@ abstract contract Clone is IClone {
     /// @notice Retrieves appended arguments from the clone.
     /// @dev Leverages `LibClone` to extract arguments from the clone's runtime bytecode.
     /// @return appendedBytes The appended bytes extracted from the clone.
-    function getAppendedBytes() external returns (bytes memory appendedBytes) {
+    function getAppendedBytes() external view returns (bytes memory appendedBytes) {
         return _getAppendedBytes();
     }
 
@@ -37,7 +37,7 @@ abstract contract Clone is IClone {
     /// @notice Internal function to retrieve appended arguments from the clone.
     /// @dev Uses `LibClone` utility to extract the arguments.
     /// @return appendedBytes The appended bytes extracted from the clone.
-    function _getAppendedBytes() internal virtual returns (bytes memory appendedBytes) {
+    function _getAppendedBytes() internal view virtual returns (bytes memory appendedBytes) {
         return LibClone.argsOnClone(address(this));
     }
 }

--- a/packages/contracts/contracts/test/examples/Advanced.t.sol
+++ b/packages/contracts/contracts/test/examples/Advanced.t.sol
@@ -67,7 +67,7 @@ contract AdvancedChecker is Test {
         advancedChecker.initialize();
     }
 
-    function test_checker_getAppendedBytes() public {
+    function test_checker_getAppendedBytes() public view {
         assertEq(
             advancedChecker.getAppendedBytes(),
             abi.encode(address(signupNft), address(rewardNft), address(baseChecker), 1, 0, 10)
@@ -217,7 +217,7 @@ contract AdvancedPolicy is Test {
         policySkipped.initialize();
     }
 
-    function test_policy_getAppendedBytes() public {
+    function test_policy_getAppendedBytes() public view {
         assertEq(policy.getAppendedBytes(), abi.encode(address(deployer), address(advancedChecker), false, false));
         assertEq(policySkipped.getAppendedBytes(), abi.encode(address(deployer), address(advancedChecker), true, true));
     }

--- a/packages/contracts/contracts/test/examples/Base.t.sol
+++ b/packages/contracts/contracts/test/examples/Base.t.sol
@@ -50,7 +50,7 @@ contract BaseChecker is Test {
         checker.initialize();
     }
 
-    function test_checker_getAppendedBytes() public {
+    function test_checker_getAppendedBytes() public view {
         assertEq(checker.getAppendedBytes(), abi.encode(address(nft)));
     }
 
@@ -133,7 +133,7 @@ contract BasePolicy is Test {
         policy.initialize();
     }
 
-    function test_policy_getAppendedBytes() public {
+    function test_policy_getAppendedBytes() public view {
         assertEq(policy.getAppendedBytes(), abi.encode(address(deployer), address(checker)));
     }
 

--- a/packages/contracts/contracts/test/extensions/Semaphore.t.sol
+++ b/packages/contracts/contracts/test/extensions/Semaphore.t.sol
@@ -104,7 +104,7 @@ contract SemaphoreCheckerTest is Test {
         checker.initialize();
     }
 
-    function test_checker_getAppendedBytes() public {
+    function test_checker_getAppendedBytes() public view {
         assertEq(checker.getAppendedBytes(), abi.encode(address(semaphoreMock), validGroupId));
     }
 
@@ -258,7 +258,7 @@ contract SemaphorePolicyTest is Test {
         policy.initialize();
     }
 
-    function test_policy_getAppendedBytes() public {
+    function test_policy_getAppendedBytes() public view {
         assertEq(policy.getAppendedBytes(), abi.encode(address(deployer), address(checker)));
     }
 


### PR DESCRIPTION
Use view modifier to get hex bytes instead of contract response 